### PR TITLE
bug fix for viewing specific file in xiview

### DIFF
--- a/app/routes/shared.py
+++ b/app/routes/shared.py
@@ -49,7 +49,7 @@ async def get_most_recent_upload_ids(pxid, file=None):
     if file:
         filename_clean = re.sub(r'[^0-9a-zA-Z-]+', '-', file)
         query = """SELECT id FROM upload 
-                WHERE project_id = %s AND identification_file_name_clean = %s 
+                WHERE project_id = $1 AND identification_file_name_clean = $2 
                 ORDER BY upload_time DESC LIMIT 1;"""
         upload_ids = await execute_query(query, [pxid, filename_clean], fetch_one=True)
     else:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the `get_most_recent_upload_ids` function by correcting the SQL query parameter syntax from `%s` to `$1` and `$2`, ensuring compatibility with async query execution.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shared.py</strong><dd><code>Fix SQL query parameter syntax in async function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/routes/shared.py

<li>Fixed SQL query parameter syntax from <code>%s</code> to <code>$1</code> and <code>$2</code>.<br> <li> Ensured compatibility with async query execution.<br>


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xiview-api/pull/18/files#diff-49e976a0d6207211ca097393b795398b2d01095502e0feec2adc2614d5e26051">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information